### PR TITLE
store mode and temperature in eeprom

### DIFF
--- a/rfmsrc/OpenHR20/controller.c
+++ b/rfmsrc/OpenHR20/controller.c
@@ -249,6 +249,11 @@ void CTL_temp_change_inc (int8_t ch) {
 	}
 	CTL_mode_window = 0;
     PID_force_update = 9;
+	if (!CTL_mode_auto) {
+		// save temp to config.timer_mode
+		config.timer_mode = (CTL_temp_wanted << 1) + (config.timer_mode & 0x01);
+		eeprom_config_save((uint16_t)(&config.timer_mode)-(uint16_t)(&config));
+	}
 }
 
 static uint8_t menu_temp_rewoke_type;
@@ -278,7 +283,13 @@ void CTL_change_mode(int8_t m) {
     if (CTL_mode_auto && (m != CTL_CHANGE_MODE_REWOKE)) {
         CTL_temp_auto_type = RTC_ActualTimerTemperatureType(false);
         CTL_temp_wanted=(CTL_temp_auto_type != TEMP_TYPE_INVALID ? temperature_table[CTL_temp_auto_type] : 0);
-    }
+		config.timer_mode = config.timer_mode & 0x01;
+		eeprom_config_save((uint16_t)(&config.timer_mode)-(uint16_t)(&config));
+    } else {
+		// save temp to config.timer_mode
+		config.timer_mode = (CTL_temp_wanted << 1) + (config.timer_mode & 0x01);
+		eeprom_config_save((uint16_t)(&config.timer_mode)-(uint16_t)(&config));
+	}
     CTL_mode_window = 0;
 }
 

--- a/rfmsrc/OpenHR20/eeprom.h
+++ b/rfmsrc/OpenHR20/eeprom.h
@@ -82,7 +82,8 @@ typedef struct { // each variables must be uint8_t or int8_t without exception
     /* 1f */ uint8_t temp_cal_table4; //!< temperature calibration table
     /* 20 */ uint8_t temp_cal_table5; //!< temperature calibration table
     /* 21 */ uint8_t temp_cal_table6; //!< temperature calibration table
-    /* 22 */ uint8_t timer_mode; //!< =0 only one program, =1 programs for weekdays
+    /* 22 */ uint8_t timer_mode;	//!< bit0: timermode; =0 only one program, =1 programs for weekdays
+									// >1 manual mode, the higher bits contain the saved temperature << 1
 #if HR25
     /*    */ uint8_t bat_half_thld; //!< treshold for half battery indicator [unit 0.02V]=[unit 0.01V per cell]
 #endif
@@ -245,7 +246,8 @@ uint8_t EEPROM ee_config[][4] ={  // must be alligned to 4 bytes
   /* 20 */  {614-549,614-549,      16,      255},   //!< value for 10C => 614 temperature calibration table
   /* 21 */  {675-614,675-614,      16,      255},   //!< value for 05C => 675 temperature calibration table
 #endif
-  /* 22 */  {0,           0,        0,        1},   //!< timer_mode; =0 only one program, =1 programs for weekdays 
+  /* 22 */  {0,           0,        0, ((TEMP_MAX+1)<<1)+1},	//!< bit0: timer_mode; =0 only one program, =1 programs for weekdays
+																// >1 manual mode, the higher bits contain the saved temperature << 1
 #if HR25
   /*    */  {125,       125,       80,      160},   //!< bat_half_thld; treshold for half battery indicator [unit 0.02V]=[unit 0.01V per cell]
 #endif

--- a/rfmsrc/OpenHR20/main.c
+++ b/rfmsrc/OpenHR20/main.c
@@ -473,6 +473,13 @@ static inline void init(void)
 
 	// init keyboard
     state_wheel_prev = ~PINB & (KBI_ROT1 | KBI_ROT2);
+
+	// restore saved temperature from config.timer
+    if ( config.timer_mode > 1 ) {
+		CTL_temp_wanted = config.timer_mode >> 1;
+		CTL_mode_auto = false;
+	}
+
 }
 
 // interrupts: 


### PR DESCRIPTION
	Save the temperature to the eeprom when it is set manually.
	I use the higher bits in config.timer_mode for saving the
	last temperature and restore the settings on reboot. I have
	unused rooms, that get heated when I change the batteries
	and forget to switch back to manual mode and set the
	temperature.