### PR TITLE
reset buffer before sending new data

### DIFF
--- a/rfmsrc/OpenHR20/com.c
+++ b/rfmsrc/OpenHR20/com.c
@@ -328,6 +328,7 @@ void COM_print_debug(uint8_t type) {
 #if (RFM==1)
     bool sync = (type==2);
     if (!sync) {
+        wireless_buf_ptr=0;
         wireless_async=true;
         wireless_putchar('D');
     }

--- a/rfmsrc/common/rfm.c
+++ b/rfmsrc/common/rfm.c
@@ -142,17 +142,15 @@ void RFM_init(void)
 	// 5. Receiver Control Command
 	RFM_SPI_16(
 		RFM_RX_CONTROL_P20_VDI  | 
-		RFM_RX_CONTROL_VDI_FAST |
+		RFM_RX_CONTROL_VDI_MED |
 		RFM_RX_CONTROL_BW(RFM_BAUD_RATE) |
-		RFM_RX_CONTROL_GAIN_14   |
-		RFM_RX_CONTROL_RSSI_97
+		RFM_RX_CONTROL_GAIN_6   |
+		RFM_RX_CONTROL_RSSI_103
 	 );
 
 	// 6. Data Filter Command
 	RFM_SPI_16(
-		RFM_DATA_FILTER_AL      |
-		RFM_DATA_FILTER_ML      |
-		RFM_DATA_FILTER_DQD(3)             
+		RFM_DATA_FILTER_DQD(4)
 	 );
 
 	// 7. FIFO and Reset Mode Command

--- a/rfmsrc/common/rfm.h
+++ b/rfmsrc/common/rfm.h
@@ -273,7 +273,7 @@
 //#define RFM_RX_CONTROL_RSSI_67   0x9006 // DRSSI threshold -67dbm // RF12B reserved
 //#define RFM_RX_CONTROL_RSSI_61   0x9007 // DRSSI threshold -61dbm // RF12B reserved
 
-#define RFM_RX_CONTROL_BW(baud)		(((baud)<8000) ? \
+#define RFM_RX_CONTROL_BW(baud)		(((baud)<20000) ? \
 									RFM_RX_CONTROL_BW_67 : \
 									( \
 										((baud)<30000) ? \
@@ -388,7 +388,7 @@
 #define RFM_TX_CONTROL_MOD_240   0x98F0
 #define RFM_TX_CONTROL_MP        0x9900
 
-#define RFM_TX_CONTROL_MOD(baud)	(((baud)<8000) ? \
+#define RFM_TX_CONTROL_MOD(baud)	(((baud)<20000) ? \
 									RFM_TX_CONTROL_MOD_45 : \
 									( \
 										((baud)<30000) ? \

--- a/rfmsrc/common/rfm.h
+++ b/rfmsrc/common/rfm.h
@@ -391,10 +391,10 @@
 #define RFM_TX_CONTROL_MOD(baud)	(((baud)<8000) ? \
 									RFM_TX_CONTROL_MOD_45 : \
 									( \
-										((baud)<20000) ? \
+										((baud)<30000) ? \
 										RFM_TX_CONTROL_MOD_60 : \
 										( \
-											((baud)<30000) ? \
+											((baud)<40000) ? \
 											RFM_TX_CONTROL_MOD_75 : \
 											( \
 												((baud)<40000) ? \

--- a/rfmsrc/common/wireless.h
+++ b/rfmsrc/common/wireless.h
@@ -67,11 +67,11 @@ extern uint8_t wl_force_addr2;
 extern uint32_t wl_force_flags;
 
 #if !defined(MASTER_CONFIG_H)
-#define WLTIME_SYNC (0xfd)  // prepare to receive timesync / slave only 
-#define WLTIME_START (RTC_TIMER_CALC(50)) // communication start
+#define WLTIME_SYNC (0xfa)  // prepare to receive timesync / slave only 
+#define WLTIME_START (RTC_TIMER_CALC(200)) // communication start
 #define WLTIME_TIMEOUT (RTC_TIMER_CALC(80)) // slave RX timeout
-#define WLTIME_SYNC_TIMEOUT (RTC_TIMER_CALC(50)) // slave RX timeout
-#define WLTIME_STOP (RTC_TIMER_CALC(900)) // last possible communication
+#define WLTIME_SYNC_TIMEOUT (RTC_TIMER_CALC(80)) // slave RX timeout
+#define WLTIME_STOP (RTC_TIMER_CALC(700)) // last possible communication
 #endif
 #define WLTIME_LED_TIMEOUT (RTC_TIMER_CALC(300)) // packet blink time
 


### PR DESCRIPTION
This change keeps the packets from growing, which in bad radio conditions further reduces the probability for reaching the master