### PR TITLE
Enabled UART by default for non RFM build

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -78,7 +78,9 @@
 #if THERMOTRONIC != 1 //No serialport implementet yet
 // Note we should only enable of of the following at one time
 /* we support UART */
-//#define COM_UART 1
+#if !RFM
+#define COM_UART 1
+#endif
 
 /* Our default Adress, if not set or invalid */
 /* #define COM_DEF_ADR 1 */


### PR DESCRIPTION
Hello,
I just figured out that UART was disabled by default for a non RFM build. 
I'm not sure if this was by intention. 
From the documentation of this project I thought this is enabled by default. 

Regards
Feserich
